### PR TITLE
Update mkdoc: check github action

### DIFF
--- a/.github/workflows/mkdocs-test.yml
+++ b/.github/workflows/mkdocs-test.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install pipenv
-          pipenv --python python3.6
+          pipenv --python 3
           pipenv install
       - run: cd unofficial_irods_documentation && pipenv run mkdocs build

--- a/.github/workflows/mkdocs-test.yml
+++ b/.github/workflows/mkdocs-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.10.13'
           architecture: 'x64'
 
       - name: Install dependencies

--- a/.github/workflows/mkdocs-test.yml
+++ b/.github/workflows/mkdocs-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/unofficial_irods_documentation/.gitignore
+++ b/unofficial_irods_documentation/.gitignore
@@ -1,1 +1,5 @@
+bin/
+lib/
+lib64
+pyvenv.cfg
 site/


### PR DESCRIPTION
Ubuntu 18.04 is no longer supported by  github actions, so this PR updates to _mkdocs: check_ to run on `ubuntu-latest`. This environment doesn't support Python 3.6, so the action was also updated to use Python 3.10.